### PR TITLE
Documentation updates to clear confusion around 10.0.2.2 across Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ If you're past this, you deserve one more tap on the shoulder, we're almost ther
     }
   }
   ```
-  
+
+  **Note**: if you're deploying this on a Mac and would like to test it with Android, use http://10.0.0.2 instead of http://127.0.0.1 as `_baseUrl_` in the config file above. [For more information, see this Stackoverflow thread](https://stackoverflow.com/questions/9808560/why-do-we-use-10-0-2-2-to-connect-to-local-web-server-instead-of-using-computer).  
 When you saved the config file, open a console and cd into the root of the NodeJS repo
 
 * First, install it:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ If you're past this, you deserve one more tap on the shoulder, we're almost ther
   }
   ```
 
-  **Note**: if you're deploying this on a Mac and would like to test it with Android, use http://10.0.0.2 instead of http://127.0.0.1 as `_baseUrl_` in the config file above. [For more information, see this Stackoverflow thread](https://stackoverflow.com/questions/9808560/why-do-we-use-10-0-2-2-to-connect-to-local-web-server-instead-of-using-computer).  
+  **Note**: if you're deploying this on a Mac and would like to test it with Android, use http://10.0.0.2 instead of http://127.0.0.1 as `baseUrl` in the config file above. [For more information, see this Stackoverflow thread](https://stackoverflow.com/questions/9808560/why-do-we-use-10-0-2-2-to-connect-to-local-web-server-instead-of-using-computer).  
 When you saved the config file, open a console and cd into the root of the NodeJS repo
 
 * First, install it:

--- a/android/readme.md
+++ b/android/readme.md
@@ -47,7 +47,8 @@ appbackend=URL of your ZeroKit Node backend, by default it's http://10.0.2.2:300
 objectserver=IP of your ROS with port, by default it's 10.0.2.2:9080 - see Note below
 ```
 
-* **Note**: the Android emulator doesn't like 127.0.0.1 addresses for servers running on the same box. Use 10.0.2.2 instead; see this StackOverflow post for more info.
+  **Note**: the Android emulator doesn't like 127.0.0.1 addresses for servers running on the same box. Use 10.0.2.2 instead. [For more information, see this Stackoverflow thread](https://stackoverflow.com/questions/9808560/why-do-we-use-10-0-2-2-to-connect-to-local-web-server-instead-of-using-computer).
+
 
 ## Step 3: Test-drive the app
 Choose one of the latest emulator devices, for example **Google's Pixel XL**, and run the app:

--- a/ios/README.md
+++ b/ios/README.md
@@ -43,13 +43,13 @@ In the `RealmTasks Shared/Config.plist` file set the values for `ZeroKitAPIBaseU
 <key>RealmPort</key>
 <integer>9080</integer>
 <key>RealmHost</key>
-<string>Your realm host, eg. 10.0.2.2</string>
+<string>Your realm host, eg. 127.0.0.1</string>
 <key>ZeroKitServiceURL</key>
 <string>This is your Service URL https://abcde12345.api.tresorit.io</string>
 <key>ZeroKitClientId</key>
 <string>This is your Client ID abcde12345_fghij67890</string>
 <key>ZeroKitAppBackend</key>
-<string>This is your ZeroKit node backend http://10.0.2.2:3000</string>
+<string>This is your ZeroKit node backend http://127.0.0.1:3000</string>
 ```
 
 # Step 3: Test-drive the app

--- a/ios/README.md
+++ b/ios/README.md
@@ -52,6 +52,9 @@ In the `RealmTasks Shared/Config.plist` file set the values for `ZeroKitAPIBaseU
 <string>This is your ZeroKit node backend http://127.0.0.1:3000</string>
 ```
 
+  **Note**: even though you set up your ZeroKit backend with the http://10.0.0.2 ZeroKit backend Url, you should still refer to it as http://127.0.0.1 in your iPhone app's config file. The iOS emulator won't work with the 10.0.2.2 IP addresses. Yes, the beauties of multi-platform development...
+  
+
 # Step 3: Test-drive the app
 
 You are now ready to **Build and Run** (**⌘R**) the app in Xcode!


### PR DESCRIPTION
- Android doesn't work with the 127.0.0.1 ZeroKit backend IP. It needs a fake 10.0.2.2 IP instead
- iOS doesn't recognize 10.0.2.2, it wants 127.0.0.1 instead
- Yet, the ZeroKit node backend needs to be configured with 10.0.2.2 in order to work! :)

This update is meant to clear this and make sure that readers will succeed with both platforms.